### PR TITLE
Trial fix of Disaggregation Converter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,9 +32,9 @@ nosetests.xml
 *.mo
 
 # Mr Developer
-.mr.developer.cfg
-.project
-.pydevproject
+*.mr.developer.cfg
+*.project
+*.pydevproject
 
 # Vim
 *.swp

--- a/.gitignore
+++ b/.gitignore
@@ -37,4 +37,8 @@ nosetests.xml
 .pydevproject
 
 # Vim
-.swp
+*.swp
+
+# GMT
+.gmtcommands4
+.gmtdefaults4

--- a/oq_output/disaggregation_converter.py
+++ b/oq_output/disaggregation_converter.py
@@ -46,9 +46,11 @@ using GMT
 import os
 import argparse
 import numpy
+import utils
 from lxml import etree
 from collections import OrderedDict
 from subprocess import call
+
 
 NRML='{http://openquake.org/xmlns/nrml/0.4}'
 
@@ -140,7 +142,10 @@ def save_disagg_to_csv(nrml_disaggregation, output_dir, plot):
         if len(axis) == 1:
             values = numpy.array([axis[0], matrix.flatten()]).T
         else:
-            grids = numpy.meshgrid(*axis, indexing='ij')
+            try:
+                grids = numpy.meshgrid(*axis, indexing='ij')
+            except:
+                grids = utils.meshgrid(*axis, indexing='ij')
             values = [g.flatten() for g in grids]
             values.append(matrix.flatten())
             values = numpy.array(values).T

--- a/oq_output/utils.py
+++ b/oq_output/utils.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python
+# LICENSE
+#
+# Copyright (c) 2014, GEM Foundation, G. Weatherill, M. Pagani, D. Monelli.
+#
+# The nrml_convertes is free software: you can redistribute
+# it and/or modify it under the terms of the GNU Affero General Public
+# License as published by the Free Software Foundation, either version
+# 3 of the License, or (at your option) any later version.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with OpenQuake. If not, see <http://www.gnu.org/licenses/>
+#
+# DISCLAIMER
+# 
+# The software nrml_convertes provided herein is released as a prototype
+# implementation on behalf of scientists and engineers working within the GEM
+# Foundation (Global Earthquake Model).
+#
+# It is distributed for the purpose of open collaboration and in the
+# hope that it will be useful to the scientific, engineering, disaster
+# risk and software design communities.
+#
+# The software is NOT distributed as part of GEM's OpenQuake suite
+# (http://www.globalquakemodel.org/openquake) and must be considered as a
+# separate entity. The software provided herein is designed and implemented
+# by scientific staff. It is not developed to the design standards, nor
+# subject to same level of critical review by professional software
+# developers, as GEM's OpenQuake software suite.
+#
+# Feedback and contribution to the software is welcome, and can be
+# directed to the hazard scientific staff of the GEM Model Facility
+# (hazard@globalquakemodel.org).
+#
+# The nrml_convertes is therefore distributed WITHOUT ANY WARRANTY; without
+# even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+# PURPOSE. See the GNU General Public License for more details.
+#
+# The GEM Foundation, and the authors of the software, assume no liability for
+# use of the software.
+"""
+Utility functions for use with the OQ Output converters
+"""
+import numpy as np
+
+# Based on scitools meshgrid
+def meshgrid(*xi, **kwargs):
+    """
+    Return coordinate matrices from two or more coordinate vectors.
+
+    Make N-D coordinate arrays for vectorized evaluations of
+    N-D scalar/vector fields over N-D grids, given
+    one-dimensional coordinate arrays x1, x2,..., xn.
+
+    Parameters
+    ----------
+    x1, x2,..., xn : array_like
+        1-D arrays representing the coordinates of a grid.
+    indexing : {'xy', 'ij'}, optional
+        Cartesian ('xy', default) or matrix ('ij') indexing of output.
+        See Notes for more details.
+    sparse : bool, optional
+         If True a sparse grid is returned in order to conserve memory.
+         Default is False.
+    copy : bool, optional
+        If False, a view into the original arrays are returned in
+        order to conserve memory.  Default is True.  Please note that
+        ``sparse=False, copy=False`` will likely return non-contiguous arrays.
+        Furthermore, more than one element of a broadcast array may refer to
+        a single memory location.  If you need to write to the arrays, make
+        copies first.
+
+    Returns
+    -------
+    X1, X2,..., XN : ndarray
+        For vectors `x1`, `x2`,..., 'xn' with lengths ``Ni=len(xi)`` ,
+        return ``(N1, N2, N3,...Nn)`` shaped arrays if indexing='ij'
+        or ``(N2, N1, N3,...Nn)`` shaped arrays if indexing='xy'
+        with the elements of `xi` repeated to fill the matrix along
+        the first dimension for `x1`, the second for `x2` and so on.
+
+    Notes
+    -----
+    This function supports both indexing conventions through the indexing keyword
+    argument.  Giving the string 'ij' returns a meshgrid with matrix indexing,
+    while 'xy' returns a meshgrid with Cartesian indexing.  In the 2-D case
+    with inputs of length M and N, the outputs are of shape (N, M) for 'xy'
+    indexing and (M, N) for 'ij' indexing.  In the 3-D case with inputs of
+    length M, N and P, outputs are of shape (N, M, P) for 'xy' indexing and (M,
+    N, P) for 'ij' indexing.  The difference is illustrated by the following
+    code snippet::
+
+        xv, yv = meshgrid(x, y, sparse=False, indexing='ij')
+        for i in range(nx):
+            for j in range(ny):
+                # treat xv[i,j], yv[i,j]
+
+        xv, yv = meshgrid(x, y, sparse=False, indexing='xy')
+        for i in range(nx):
+            for j in range(ny):
+                # treat xv[j,i], yv[j,i]
+
+    See Also
+    --------
+    index_tricks.mgrid : Construct a multi-dimensional "meshgrid"
+                     using indexing notation.
+    index_tricks.ogrid : Construct an open multi-dimensional "meshgrid"
+                     using indexing notation.
+
+    Examples
+    --------
+    >>> nx, ny = (3, 2)
+    >>> x = np.linspace(0, 1, nx)
+    >>> y = np.linspace(0, 1, ny)
+    >>> xv, yv = meshgrid(x, y)
+    >>> xv
+    array([[ 0. ,  0.5,  1. ],
+           [ 0. ,  0.5,  1. ]])
+    >>> yv
+    array([[ 0.,  0.,  0.],
+           [ 1.,  1.,  1.]])
+    >>> xv, yv = meshgrid(x, y, sparse=True)  # make sparse output arrays
+    >>> xv
+    array([[ 0. ,  0.5,  1. ]])
+    >>> yv
+    array([[ 0.],
+           [ 1.]])
+
+    `meshgrid` is very useful to evaluate functions on a grid.
+
+    >>> x = np.arange(-5, 5, 0.1)
+    >>> y = np.arange(-5, 5, 0.1)
+    >>> xx, yy = meshgrid(x, y, sparse=True)
+    >>> z = np.sin(xx**2 + yy**2) / (xx**2 + yy**2)
+    >>> h = plt.contourf(x,y,z)
+
+    """
+    if len(xi) < 2:
+        msg = 'meshgrid() takes 2 or more arguments (%d given)' % int(len(xi) > 0)
+        raise ValueError(msg)
+
+    args = np.atleast_1d(*xi)
+    ndim = len(args)
+
+    copy_ = kwargs.get('copy', True)
+    sparse = kwargs.get('sparse', False)
+    indexing = kwargs.get('indexing', 'xy')
+    if not indexing in ['xy', 'ij']:
+        raise ValueError("Valid values for `indexing` are 'xy' and 'ij'.")
+
+    s0 = (1,) * ndim
+    output = [x.reshape(s0[:i] + (-1,) + s0[i + 1::]) for i, x in enumerate(args)]
+
+    shape = [x.size for x in output]
+
+    if indexing == 'xy':
+        # switch first and second axis
+        output[0].shape = (1, -1) + (1,)*(ndim - 2)
+        output[1].shape = (-1, 1) + (1,)*(ndim - 2)
+        shape[0], shape[1] = shape[1], shape[0]
+
+    if sparse:
+        if copy_:
+            return [x.copy() for x in output]
+        else:
+            return output
+    else:
+        # Return the full N-D matrix (not only the 1-D vector)
+        if copy_:
+            mult_fact = np.ones(shape, dtype=int)
+            return [x * mult_fact for x in output]
+        else:
+            return np.broadcast_arrays(*output)


### PR DESCRIPTION
In the OQ Virtualbox images the Disaggregation converter has been failing on platforms using Numpy 1.6 or earlier due to the use of the "indexing" keyword argument, which was introduced in Numpy 1.8. We sidestep this problem by taking the code from the Numpy 1.8 meshgrid function and pasting it into a new module called utils.py. A try-except block is then introduced into the disaggregation coverter that will use utils.meshgrid rather than numpy.meshgrid in the case when the "indexing" argument isn't supported.