### PR TITLE
Script glue

### DIFF
--- a/ci_run_tests.sh
+++ b/ci_run_tests.sh
@@ -278,7 +278,7 @@ fi
     # install sources of this package
     git archive --prefix ${GEM_GIT_PACKAGE}/ HEAD | ssh $lxc_ip "tar xv"
 
-    ssh $lxc_ip "export DISPLAY=:1 ; export PYTHONPATH="\$PWD/oq-hazardlib:\$PWD/oq-risklib" ; cd $GEM_GIT_PACKAGE ; nosetests --with-xunit -v --with-coverage || true"
+    ssh $lxc_ip "export PYTHONPATH="\$PWD/oq-hazardlib:\$PWD/oq-risklib" ; cd $GEM_GIT_PACKAGE ; nosetests --with-xunit -v --with-coverage || true"
 
     trap ERR
 

--- a/ci_run_tests.sh
+++ b/ci_run_tests.sh
@@ -377,7 +377,6 @@ _guest_display_get () {
 
     ssh $lxc_ip 'x_list="$(ls /tmp/.X*-lock)"
 for x in $(echo "$x_list"); do
-    cat $x
     if sudo kill -0 $(cat $x) >/dev/null 2>&1; then
         echo "$x" | sed '"'"'s@^/tmp/.X@:@g;s@-lock$@@g'"'"'
         return 0

--- a/ci_run_tests.sh
+++ b/ci_run_tests.sh
@@ -278,7 +278,7 @@ fi
     # install sources of this package
     git archive --prefix ${GEM_GIT_PACKAGE}/ HEAD | ssh $lxc_ip "tar xv"
 
-    ssh $lxc_ip "export PYTHONPATH="\$PWD/oq-hazardlib:\$PWD/oq-risklib" ; cd $GEM_GIT_PACKAGE ; nosetests --with-xunit -v --with-coverage || true"
+    ssh $lxc_ip "export DISPLAY=:1 ; export PYTHONPATH="\$PWD/oq-hazardlib:\$PWD/oq-risklib" ; cd $GEM_GIT_PACKAGE ; nosetests --with-xunit -v --with-coverage || true"
 
     trap ERR
 

--- a/ci_run_tests.sh
+++ b/ci_run_tests.sh
@@ -377,6 +377,7 @@ _guest_display_get () {
 
     ssh $lxc_ip 'x_list="$(ls /tmp/.X*-lock)"
 for x in $(echo "$x_list"); do
+    cat $x
     if sudo kill -0 $(cat $x) >/dev/null 2>&1; then
         echo "$x" | sed '"'"'s@^/tmp/.X@:@g;s@-lock$@@g'"'"'
         return 0

--- a/ci_run_tests.sh
+++ b/ci_run_tests.sh
@@ -379,10 +379,10 @@ _guest_display_get () {
 for x in $(echo "$x_list"); do
     if sudo kill -0 $(cat $x) >/dev/null 2>&1; then
         echo "$x" | sed '"'"'s@^/tmp/.X@:@g;s@-lock$@@g'"'"'
-        return 0
+        exit 0
     fi
 done
-return 1'
+exit 1'
 }
 
 deps_check_or_clone () {

--- a/oq_output/uhs_converter.py
+++ b/oq_output/uhs_converter.py
@@ -165,8 +165,9 @@ def save_uhs_to_csv(nrml_uhs_file, file_name_root, plot_spectra=False):
     """
     output_file = '%s.csv' % file_name_root
     if os.path.isfile(output_file):
-        raise ValueError('Output file already exists.'
-                         ' Please specify different name or remove old file')
+        raise ValueError('Output file already exists [%s].'
+                         ' Please specify different name or '
+                         'remove old file' % output_file)
 
     metadata, periods, values = parse_nrml_uhs_curves(nrml_uhs_file)
 
@@ -212,7 +213,6 @@ def set_up_arg_parser():
 
 
 if __name__ == "__main__":
-
     parser = set_up_arg_parser()
     args = parser.parse_args()
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -4,7 +4,7 @@ import shutil
 import runpy
 
 
-def gem_rmtree(path, is_mandatory=True):
+def gem_rmtree(path, is_mandatory=False):
     try:
         shutil.rmtree(path)
     except OSError:
@@ -27,12 +27,18 @@ def gem_unlink(path, is_mandatory=False):
 def gem_run_script(prog, args):
     argv_orig = sys.argv
     sys.argv = [prog] + args
+
+    syspath_orig = sys.path
+    sys.path.insert(0, os.path.dirname(prog))
+
     try:
         runpy.run_path(prog, run_name='__main__')
     except SystemExit as excp:
         sys.argv = argv_orig
+        sys.path = syspath_orig
         if excp.code == 0:
             pass
         else:
             raise
     sys.argv = argv_orig
+    sys.path = syspath_orig

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,16 @@
+import runpy
+import sys
+
+
+def gem_run_script(prog, args):
+    argv_orig = sys.argv
+    sys.argv = [prog] + args
+    try:
+        runpy.run_path(prog, run_name='__main__')
+    except SystemExit as excp:
+        sys.argv = argv_orig
+        if excp.code == 0:
+            pass
+        else:
+            raise
+    sys.argv = argv_orig

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,5 +1,27 @@
-import runpy
 import sys
+import os
+import shutil
+import runpy
+
+
+def gem_rmtree(path, is_mandatory=True):
+    try:
+        shutil.rmtree(path)
+    except OSError:
+        if is_mandatory:
+            raise
+        else:
+            pass
+
+
+def gem_unlink(path, is_mandatory=False):
+    try:
+        os.unlink(path)
+    except OSError:
+        if is_mandatory:
+            raise
+        else:
+            pass
 
 
 def gem_run_script(prog, args):

--- a/tests/oq_input_converter_test.py
+++ b/tests/oq_input_converter_test.py
@@ -39,8 +39,8 @@
 # The GEM Foundation, and the authors of the software, assume no liability for
 # use of the software.
 import os
-import subprocess
 import unittest
+from tests import gem_run_script, gem_rmtree, gem_unlink
 
 BASEPATH = os.path.join(os.path.dirname(__file__), os.path.pardir, "oq_input")
 
@@ -59,60 +59,54 @@ class SiteModelConverterTestCase(unittest.TestCase):
         """
 
         """
+        gem_unlink("dummy_site.csv")
+
         input_file = os.path.join(os.path.dirname(__file__),
                                   "..", "sample_data",
                                   "sample_site_model.xml")
-        exit_code = subprocess.call(["python",
-                                     self.prog,
-                                     "--input-xml-file",
-                                     input_file,
-                                     "--output-csv-file",
-                                     "dummy_site.csv"])
-        self.assertEqual(exit_code, 0)
+        gem_run_script(self.prog, ["--input-xml-file",
+                                   input_file,
+                                   "--output-csv-file",
+                                   "dummy_site.csv"])
         # cleanup
-        subprocess.call(["rm", "dummy_site.csv"])
+        gem_unlink("dummy_site.csv", True)
 
     def test_csv_to_xml(self):
         """
 
         """
+        gem_unlink("dummy_site.xml")
         input_file = os.path.join(os.path.dirname(__file__),
                                   "..", "sample_data",
                                   "sample_site_model.csv")
-        exit_code = subprocess.call(["python",
-                                     self.prog,
-                                     "--input-csv-file",
-                                     input_file,
-                                     "--output-xml-file",
-                                     "dummy_site.xml"])
-        self.assertEqual(exit_code, 0)
+        gem_run_script(self.prog, ["--input-csv-file",
+                                   input_file,
+                                   "--output-xml-file",
+                                   "dummy_site.xml"])
         # cleanup
-        subprocess.call(["rm", "dummy_site.xml"])
+        gem_unlink("dummy_site.xml", True)
 
     def test_roundtrip(self):
         """
 
         """
+        gem_unlink("dummy_site.csv")
+        gem_unlink("dummy_site2.xml")
         input_file = os.path.join(os.path.dirname(__file__),
                                   "..", "sample_data",
                                   "sample_site_model.xml")
-        exit_code = subprocess.call(["python",
-                                     self.prog,
-                                     "--input-xml-file",
-                                     input_file,
-                                     "--output-csv-file",
-                                     "dummy_site.csv"])
-        self.assertEqual(exit_code, 0)
+        gem_run_script(self.prog, ["--input-xml-file",
+                                   input_file,
+                                   "--output-csv-file",
+                                   "dummy_site.csv"])
 
-        exit_code = subprocess.call(["python",
-                                     self.prog,
-                                     "--input-csv-file",
-                                     "dummy_site.csv",
-                                     "--output-xml-file",
-                                     "dummy_site2.xml"])
-        self.assertEqual(exit_code, 0)
-        subprocess.call(["rm", "dummy_site.csv"])
-        subprocess.call(["rm", "dummy_site2.xml"])
+        gem_run_script(self.prog, ["--input-csv-file",
+                                   "dummy_site.csv",
+                                   "--output-xml-file",
+                                   "dummy_site2.xml"])
+
+        gem_unlink("dummy_site.csv", True)
+        gem_unlink("dummy_site2.xml", True)
 
 
 class SourceModelShapefileConverterTestCase(unittest.TestCase):
@@ -131,44 +125,42 @@ class SourceModelShapefileConverterTestCase(unittest.TestCase):
         Tests the conversion to shapefile - without validation
         """
         #output_dir = os.path.join(os.path.dirname(__file__), "outputs")
-        subprocess.call(["mkdir", "source_shp"])
-        exit_code = subprocess.call([
-            "python",
-            self.prog,
+        gem_rmtree("source_shp")
+        os.mkdir("source_shp")
+
+        gem_run_script(self.prog, [
             "--input-nrml-file",
             self.input_file,
             "--output-file",
             os.path.join("source_shp", "src_model_files")])
-        self.assertEqual(exit_code, 0)
         # Cleanup
-        subprocess.call(["rm", "-r", "source_shp"])
+        gem_rmtree("source_shp")
 
     def test_xml_to_shp_with_validation(self):
         """
         Tests the conversion to shapefile - with validation
         """
         #output_dir = os.path.join(os.path.dirname(__file__), "outputs")
-        subprocess.call(["mkdir", "source_shp"])
-        exit_code = subprocess.call([
-            "python",
-            self.prog,
+        gem_rmtree("source_shp")
+        os.mkdir("source_shp")
+        gem_run_script(self.prog, [
             "--input-nrml-file",
             self.input_file,
             "--output-file",
             os.path.join("source_shp", "src_model_files"),
             "--validate"])
-        self.assertEqual(exit_code, 0)
         # Cleanup
-        subprocess.call(["rm", "-r", "source_shp"])
+        gem_rmtree("source_shp", True)
 
     def test_shp_to_xml_no_validation(self):
         """
         """
+        gem_unlink("dummy1.xml")
+        gem_rmtree("source_shp")
+        os.mkdir("source_shp")
+
         # Build shapefiles
-        subprocess.call(["mkdir", "source_shp"])
-        exit_code = subprocess.call([
-            "python",
-            self.prog,
+        gem_run_script(self.prog, [
             "--input-nrml-file",
             self.input_file,
             "--output-file",
@@ -180,29 +172,28 @@ class SourceModelShapefileConverterTestCase(unittest.TestCase):
         simple_file = os.path.join("source_shp", "src_model_files" + "_simple")
         complex_file = os.path.join("source_shp",
                                     "src_model_files" + "_complex")
-        exit_code = subprocess.call(["python",
-                                     self.prog,
-                                     "--input-shp-files",
-                                     point_file,
-                                     area_file,
-                                     simple_file,
-                                     complex_file,
-                                     "--output-file",
-                                     "dummy1.xml"])
+        gem_run_script(self.prog, [
+            "--input-shp-files",
+            point_file,
+            area_file,
+            simple_file,
+            complex_file,
+            "--output-file",
+            "dummy1.xml"])
 
-        self.assertEqual(exit_code, 0)
         # cleanup
-        subprocess.call(["rm", "-r", "source_shp"])
-        subprocess.call(["rm", "-r", "dummy1.xml"])
+        gem_rmtree("source_shp", True)
+        gem_unlink("dummy1.xml", True)
 
     def test_shp_to_xml_validation(self):
         """
         """
         # Build shapefiles
-        subprocess.call(["mkdir", "source_shp"])
-        exit_code = subprocess.call([
-            "python",
-            self.prog,
+        gem_unlink("dummy1.xml")
+        gem_rmtree("source_shp")
+        os.mkdir("source_shp")
+
+        gem_run_script(self.prog, [
             "--input-nrml-file",
             self.input_file,
             "--output-file",
@@ -215,17 +206,14 @@ class SourceModelShapefileConverterTestCase(unittest.TestCase):
         simple_file = os.path.join("source_shp", "src_model_files" + "_simple")
         complex_file = os.path.join("source_shp",
                                     "src_model_files" + "_complex")
-        exit_code = subprocess.call(["python",
-                                     self.prog,
-                                     "--input-shp-files",
-                                     point_file,
-                                     area_file,
-                                     simple_file,
-                                     complex_file,
-                                     "--output-file",
-                                     "dummy1.xml",
-                                     "--validate"])
-        self.assertEqual(exit_code, 0)
+        gem_run_script(self.prog, ["--input-shp-files",
+                                   point_file,
+                                   area_file,
+                                   simple_file,
+                                   complex_file,
+                                   "--output-file",
+                                   "dummy1.xml",
+                                   "--validate"])
         # cleanup
-        subprocess.call(["rm", "-r", "source_shp"])
-        subprocess.call(["rm", "-r", "dummy1.xml"])
+        gem_unlink("dummy1.xml", True)
+        gem_rmtree("source_shp", True)

--- a/tests/oq_input_converter_test.py
+++ b/tests/oq_input_converter_test.py
@@ -38,13 +38,12 @@
 #
 # The GEM Foundation, and the authors of the software, assume no liability for
 # use of the software.
-
 import os
 import subprocess
 import unittest
-import numpy as np
 
 BASEPATH = os.path.join(os.path.dirname(__file__), os.path.pardir, "oq_input")
+
 
 class SiteModelConverterTestCase(unittest.TestCase):
     """
@@ -60,13 +59,13 @@ class SiteModelConverterTestCase(unittest.TestCase):
         """
 
         """
-        self.input_file = os.path.join(os.path.dirname(__file__),
-                                       "..", "sample_data",
-                                       "sample_site_model.xml")
+        input_file = os.path.join(os.path.dirname(__file__),
+                                  "..", "sample_data",
+                                  "sample_site_model.xml")
         exit_code = subprocess.call(["python",
                                      self.prog,
                                      "--input-xml-file",
-                                     self.input_file,
+                                     input_file,
                                      "--output-csv-file",
                                      "dummy_site.csv"])
         self.assertEqual(exit_code, 0)
@@ -77,13 +76,13 @@ class SiteModelConverterTestCase(unittest.TestCase):
         """
 
         """
-        self.input_file = os.path.join(os.path.dirname(__file__),
-                                       "..", "sample_data",
-                                       "sample_site_model.csv")
+        input_file = os.path.join(os.path.dirname(__file__),
+                                  "..", "sample_data",
+                                  "sample_site_model.csv")
         exit_code = subprocess.call(["python",
                                      self.prog,
                                      "--input-csv-file",
-                                     self.input_file,
+                                     input_file,
                                      "--output-xml-file",
                                      "dummy_site.xml"])
         self.assertEqual(exit_code, 0)
@@ -94,17 +93,17 @@ class SiteModelConverterTestCase(unittest.TestCase):
         """
 
         """
-        self.input_file = os.path.join(os.path.dirname(__file__),
-                                       "..", "sample_data",
-                                       "sample_site_model.xml")
+        input_file = os.path.join(os.path.dirname(__file__),
+                                  "..", "sample_data",
+                                  "sample_site_model.xml")
         exit_code = subprocess.call(["python",
                                      self.prog,
                                      "--input-xml-file",
-                                     self.input_file,
+                                     input_file,
                                      "--output-csv-file",
                                      "dummy_site.csv"])
         self.assertEqual(exit_code, 0)
-        
+
         exit_code = subprocess.call(["python",
                                      self.prog,
                                      "--input-csv-file",
@@ -143,7 +142,7 @@ class SourceModelShapefileConverterTestCase(unittest.TestCase):
         self.assertEqual(exit_code, 0)
         # Cleanup
         subprocess.call(["rm", "-r", "source_shp"])
-        
+
     def test_xml_to_shp_with_validation(self):
         """
         Tests the conversion to shapefile - with validation
@@ -196,7 +195,6 @@ class SourceModelShapefileConverterTestCase(unittest.TestCase):
         subprocess.call(["rm", "-r", "source_shp"])
         subprocess.call(["rm", "-r", "dummy1.xml"])
 
-
     def test_shp_to_xml_validation(self):
         """
         """
@@ -210,7 +208,6 @@ class SourceModelShapefileConverterTestCase(unittest.TestCase):
             "--output-file",
             os.path.join("source_shp", "src_model_files"),
             "--validate"])
-
 
         # Run test for all shapefiles
         point_file = os.path.join("source_shp", "src_model_files" + "_point")
@@ -232,4 +229,3 @@ class SourceModelShapefileConverterTestCase(unittest.TestCase):
         # cleanup
         subprocess.call(["rm", "-r", "source_shp"])
         subprocess.call(["rm", "-r", "dummy1.xml"])
-

--- a/tests/oq_output_converter_test.py
+++ b/tests/oq_output_converter_test.py
@@ -47,8 +47,10 @@ Each test tests only for successful execution, not for correctness or speed
 import os
 import subprocess
 import unittest
+from tests import gem_run_script
 
 BASEPATH = os.path.join(os.path.dirname(__file__), os.path.pardir, "oq_output")
+
 
 class HazardCurveConverterTestCase(unittest.TestCase):
     """
@@ -64,13 +66,11 @@ class HazardCurveConverterTestCase(unittest.TestCase):
         """
         Tests the execution without plotting
         """
-        exit_code = subprocess.call(["python",
-                                     self.prog,
-                                     "--input-file",
-                                     self.input_file,
-                                     "--output-file",
-                                     "dummy_hazard_curve"])
-        self.assertEqual(exit_code, 0)
+        gem_run_script(self.prog, ["--input-file",
+                                   self.input_file,
+                                   "--output-file",
+                                   "dummy_hazard_curve"])
+
         # Cleanup
         subprocess.call(["rm", "dummy_hazard_curve.csv"])
 
@@ -78,15 +78,13 @@ class HazardCurveConverterTestCase(unittest.TestCase):
         """
         Tests the execution with plotting
         """
-        exit_code = subprocess.call(["python",
-                                     self.prog,
-                                     "--input-file",
-                                     self.input_file,
-                                     "--output-file",
-                                     "dummy_hazard_curve",
-                                     "--plot-curves",
-                                     "True"])
-        self.assertEqual(exit_code, 0)
+        gem_run_script(self.prog, ["--input-file",
+                                   self.input_file,
+                                   "--output-file",
+                                   "dummy_hazard_curve",
+                                   "--plot-curves",
+                                   "True"])
+
         # Cleanup
         subprocess.call(["rm", "-r", "dummy_hazard_curve"])
         subprocess.call(["rm", "dummy_hazard_curve.csv"])
@@ -98,20 +96,19 @@ class HazardMapConverterTestCase(unittest.TestCase):
         self.input_file = os.path.join(os.path.dirname(__file__),
                                        "..", "sample_data",
                                        "hazard_map.xml")
-    
+
     def test_hazard_map_converter(self):
         """
         Tests the hazard map converter
         """
-        exit_code = subprocess.call(["python",
-                                     self.prog,
-                                     "--input-file",
-                                     self.input_file,
-                                     "--output-file",
-                                     "dummy_hazard_map"])
-        self.assertEqual(exit_code, 0)
+        gem_run_script(self.prog, ["--input-file",
+                                   self.input_file,
+                                   "--output-file",
+                                   "dummy_hazard_map"])
+
         # Cleanup
         subprocess.call(["rm", "dummy_hazard_map.csv"])
+
 
 class UHSConverterTestCase(unittest.TestCase):
     """
@@ -122,37 +119,33 @@ class UHSConverterTestCase(unittest.TestCase):
         self.input_file = os.path.join(os.path.dirname(__file__),
                                        "..", "sample_data",
                                        "uniform_hazard_spectra_short.xml")
-    
+
     def test_uhs_converter_wo_plotting(self):
         """
         Tests the execution without plotting
         """
-        exit_code = subprocess.call(["python",
-                                     self.prog,
-                                     "--input-file",
-                                     self.input_file,
-                                     "--output-file",
-                                     "dummy_uhs"])
-        self.assertEqual(exit_code, 0)
+
+        gem_run_script(self.prog, ["--input-file", self.input_file,
+                                   "--output-file", "dummy_uhs"])
+
         # Cleanup
         subprocess.call(["rm", "dummy_uhs.csv"])
-    
+
     def test_uhs_converter_plotting(self):
         """
         Tests the execution with plotting
         """
-        exit_code = subprocess.call(["python",
-                                     self.prog,
-                                     "--input-file",
-                                     self.input_file,
-                                     "--output-file",
-                                     "dummy_uhs",
-                                     "--plot-spectra",
-                                     "True"])
-        self.assertEqual(exit_code, 0)
+        gem_run_script(self.prog, ["--input-file",
+                                   self.input_file,
+                                   "--output-file",
+                                   "dummy_uhs",
+                                   "--plot-spectra",
+                                   "True"])
+
         # Cleanup
         subprocess.call(["rm", "-r", "dummy_uhs"])
         subprocess.call(["rm", "dummy_uhs.csv"])
+
 
 class ScenarioGMFConverterTestCase(unittest.TestCase):
     """
@@ -168,13 +161,11 @@ class ScenarioGMFConverterTestCase(unittest.TestCase):
         """
         Tests scenario gmf execution
         """
-        exit_code = subprocess.call(["python",
-                                     self.prog,
-                                     "--input-file",
-                                     self.input_file,
-                                     "--output-dir",
-                                     "dummy_scenario_gmf"])
-        self.assertEqual(exit_code, 0)
+        gem_run_script(self.prog, ["--input-file",
+                                   self.input_file,
+                                   "--output-dir",
+                                   "dummy_scenario_gmf"])
+
         # Cleanup
         subprocess.call(["rm", "-r", "dummy_scenario_gmf"])
 
@@ -193,15 +184,14 @@ class EventSetGMFConverterTestCase(unittest.TestCase):
         """
         Tests the execution of the gmf set converter
         """
-        exit_code = subprocess.call(["python",
-                                     self.prog,
-                                     "--input-file",
-                                     self.input_file,
-                                     "--output-dir",
-                                     "dummy_gmf_set"])
-        self.assertEqual(exit_code, 0)
+        gem_run_script(self.prog, ["--input-file",
+                                   self.input_file,
+                                   "--output-dir",
+                                   "dummy_gmf_set"])
+
         # Cleanup
         subprocess.call(["rm", "-r", "dummy_gmf_set"])
+
 
 class EventSetConverterTestCase(unittest.TestCase):
     """
@@ -217,13 +207,11 @@ class EventSetConverterTestCase(unittest.TestCase):
         """
         Tests the execution of the gmf set converter
         """
-        exit_code = subprocess.call(["python",
-                                     self.prog,
-                                     "--input-file",
-                                     self.input_file,
-                                     "--output-dir",
-                                     "dummy_event_set"])
-        self.assertEqual(exit_code, 0)
+        gem_run_script(self.prog, ["--input-file",
+                                   self.input_file,
+                                   "--output-dir",
+                                   "dummy_event_set"])
+
         # Cleanup
         subprocess.call(["rm", "-r", "dummy_event_set"])
 
@@ -242,12 +230,10 @@ class DisaggregationConverterTestCase(unittest.TestCase):
         """
         Tests the execution of the disaggregation converter
         """
-        exit_code = subprocess.call(["python",
-                                     self.prog,
-                                     "--input-file",
-                                     self.input_file,
-                                     "--output-dir",
-                                     "dummy_disag"])
-        self.assertEqual(exit_code, 0)
+        gem_run_script(self.prog, ["--input-file",
+                                   self.input_file,
+                                   "--output-dir",
+                                   "dummy_disag"])
+
         # Cleanup
         subprocess.call(["rm", "-r", "dummy_disag"])

--- a/tests/oq_output_converter_test.py
+++ b/tests/oq_output_converter_test.py
@@ -143,8 +143,8 @@ class UHSConverterTestCase(unittest.TestCase):
         Tests the execution with plotting
         """
         gem_rmtree("dummy_uhs")
-        gem_unlink("dummy_uhs.csv"
-)
+        gem_unlink("dummy_uhs.csv")
+
         gem_run_script(self.prog, ["--input-file",
                                    self.input_file,
                                    "--output-file",

--- a/tests/oq_output_converter_test.py
+++ b/tests/oq_output_converter_test.py
@@ -45,9 +45,8 @@ Each test tests only for successful execution, not for correctness or speed
 """
 
 import os
-import subprocess
 import unittest
-from tests import gem_run_script
+from tests import gem_run_script, gem_rmtree, gem_unlink
 
 BASEPATH = os.path.join(os.path.dirname(__file__), os.path.pardir, "oq_output")
 
@@ -66,18 +65,23 @@ class HazardCurveConverterTestCase(unittest.TestCase):
         """
         Tests the execution without plotting
         """
+        gem_unlink("dummy_hazard_curve.csv")
+
         gem_run_script(self.prog, ["--input-file",
                                    self.input_file,
                                    "--output-file",
                                    "dummy_hazard_curve"])
 
         # Cleanup
-        subprocess.call(["rm", "dummy_hazard_curve.csv"])
+        gem_unlink("dummy_hazard_curve.csv", True)
 
     def test_plotting(self):
         """
         Tests the execution with plotting
         """
+        gem_rmtree("dummy_hazard_curve")
+        gem_unlink("dummy_hazard_curve.csv")
+
         gem_run_script(self.prog, ["--input-file",
                                    self.input_file,
                                    "--output-file",
@@ -86,8 +90,8 @@ class HazardCurveConverterTestCase(unittest.TestCase):
                                    "True"])
 
         # Cleanup
-        subprocess.call(["rm", "-r", "dummy_hazard_curve"])
-        subprocess.call(["rm", "dummy_hazard_curve.csv"])
+        gem_rmtree("dummy_hazard_curve", True)
+        gem_unlink("dummy_hazard_curve.csv", True)
 
 
 class HazardMapConverterTestCase(unittest.TestCase):
@@ -101,13 +105,15 @@ class HazardMapConverterTestCase(unittest.TestCase):
         """
         Tests the hazard map converter
         """
+        gem_unlink("dummy_hazard_map.csv")
+
         gem_run_script(self.prog, ["--input-file",
                                    self.input_file,
                                    "--output-file",
                                    "dummy_hazard_map"])
 
         # Cleanup
-        subprocess.call(["rm", "dummy_hazard_map.csv"])
+        gem_unlink("dummy_hazard_map.csv", True)
 
 
 class UHSConverterTestCase(unittest.TestCase):
@@ -124,17 +130,21 @@ class UHSConverterTestCase(unittest.TestCase):
         """
         Tests the execution without plotting
         """
+        gem_unlink("dummy_uhs.csv")
 
         gem_run_script(self.prog, ["--input-file", self.input_file,
                                    "--output-file", "dummy_uhs"])
 
         # Cleanup
-        subprocess.call(["rm", "dummy_uhs.csv"])
+        gem_unlink("dummy_uhs.csv", True)
 
     def test_uhs_converter_plotting(self):
         """
         Tests the execution with plotting
         """
+        gem_rmtree("dummy_uhs")
+        gem_unlink("dummy_uhs.csv"
+)
         gem_run_script(self.prog, ["--input-file",
                                    self.input_file,
                                    "--output-file",
@@ -143,8 +153,8 @@ class UHSConverterTestCase(unittest.TestCase):
                                    "True"])
 
         # Cleanup
-        subprocess.call(["rm", "-r", "dummy_uhs"])
-        subprocess.call(["rm", "dummy_uhs.csv"])
+        gem_rmtree("dummy_uhs", True)
+        gem_unlink("dummy_uhs.csv", True)
 
 
 class ScenarioGMFConverterTestCase(unittest.TestCase):
@@ -161,13 +171,15 @@ class ScenarioGMFConverterTestCase(unittest.TestCase):
         """
         Tests scenario gmf execution
         """
+        gem_rmtree("dummy_scenario_gmf")
+
         gem_run_script(self.prog, ["--input-file",
                                    self.input_file,
                                    "--output-dir",
                                    "dummy_scenario_gmf"])
 
         # Cleanup
-        subprocess.call(["rm", "-r", "dummy_scenario_gmf"])
+        gem_rmtree("dummy_scenario_gmf", True)
 
 
 class EventSetGMFConverterTestCase(unittest.TestCase):
@@ -184,13 +196,15 @@ class EventSetGMFConverterTestCase(unittest.TestCase):
         """
         Tests the execution of the gmf set converter
         """
+        gem_rmtree("dummy_gmf_set")
+
         gem_run_script(self.prog, ["--input-file",
                                    self.input_file,
                                    "--output-dir",
                                    "dummy_gmf_set"])
 
         # Cleanup
-        subprocess.call(["rm", "-r", "dummy_gmf_set"])
+        gem_rmtree("dummy_gmf_set", True)
 
 
 class EventSetConverterTestCase(unittest.TestCase):
@@ -207,13 +221,15 @@ class EventSetConverterTestCase(unittest.TestCase):
         """
         Tests the execution of the gmf set converter
         """
+        gem_rmtree("dummy_event_set")
+
         gem_run_script(self.prog, ["--input-file",
                                    self.input_file,
                                    "--output-dir",
                                    "dummy_event_set"])
 
         # Cleanup
-        subprocess.call(["rm", "-r", "dummy_event_set"])
+        gem_rmtree("dummy_event_set", True)
 
 
 class DisaggregationConverterTestCase(unittest.TestCase):
@@ -230,10 +246,12 @@ class DisaggregationConverterTestCase(unittest.TestCase):
         """
         Tests the execution of the disaggregation converter
         """
+        gem_rmtree("dummy_disag")
+
         gem_run_script(self.prog, ["--input-file",
                                    self.input_file,
                                    "--output-dir",
                                    "dummy_disag"])
 
         # Cleanup
-        subprocess.call(["rm", "-r", "dummy_disag"])
+        gem_rmtree("dummy_disag", True)


### PR DESCRIPTION
more isolation: all temporary output files are precautionarily deleted (if already exists
more information: all scripts are runned inside the same nose context with the real traceback logged
more clean: pyflakes analysis suggests some cleanup
Tests results at: https://ci.openquake.org/job/zdevel_nrml_converters/28/testReport/